### PR TITLE
Please pull in a patch to fix build with LLVM backend

### DIFF
--- a/OpenSSL/BN.hsc
+++ b/OpenSSL/BN.hsc
@@ -1,5 +1,6 @@
 {-# LANGUAGE ForeignFunctionInterface #-}
 {-# LANGUAGE BangPatterns #-}
+{-# OPTIONS_GHC -fno-warn-unused-do-bind #-}
 
 #include "HsOpenSSL.h"
 
@@ -147,10 +148,10 @@ newBN i = do
 -- to
 
 foreign import ccall unsafe "memcpy"
-        _copy_in :: ByteArray## -> Ptr () -> CSize -> IO ()
+        _copy_in :: ByteArray## -> Ptr () -> CSize -> IO (Ptr ())
 
 foreign import ccall unsafe "memcpy"
-        _copy_out :: Ptr () -> ByteArray## -> CSize -> IO ()
+        _copy_out :: Ptr () -> ByteArray## -> CSize -> IO (Ptr ())
 
 -- These are taken from Data.Binary's disabled fast Integer support
 data ByteArray = BA  !ByteArray##

--- a/OpenSSL/Cipher.hsc
+++ b/OpenSSL/Cipher.hsc
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -fno-warn-unused-do-bind #-}
+
 #include "HsOpenSSL.h"
 #include "openssl/aes.h"
 
@@ -43,10 +45,10 @@ data AESCtx = AESCtx
                 Mode
 
 foreign import ccall unsafe "memcpy"
-        _memcpy :: Ptr CUChar -> Ptr CChar -> CSize -> IO ()
+        _memcpy :: Ptr CUChar -> Ptr CChar -> CSize -> IO (Ptr CUChar)
 
 foreign import ccall unsafe "memset"
-        _memset :: Ptr CUChar -> CChar -> CSize -> IO ()
+        _memset :: Ptr CUChar -> CChar -> CSize -> IO (Ptr CUChar)
 
 foreign import ccall unsafe "AES_set_encrypt_key"
         _AES_set_encrypt_key :: Ptr CChar -> CInt -> Ptr AES_KEY -> IO CInt


### PR DESCRIPTION
Hi,

This patch fixes HsOpenSSL to work with the LLVM backend of GHC. The reason HsOpenSSL doesn't compile with LLVM is due to the different definitions of memcpy and memset that are import using FFI then the actual underlying C function.

This is arguably a bug with the LLVM backend which is being worked on:

http://hackage.haskell.org/trac/ghc/ticket/5486

However, this patch allows HsOpenSSL to compile with the LLVM backend today while the fix to GHC is for the future.

Cheers,
David
