### PR TITLE
Added raw pointer read/write operations

### DIFF
--- a/HsOpenSSL.cabal
+++ b/HsOpenSSL.cabal
@@ -15,7 +15,7 @@ Description:
     encourages you to use and improve the tls package instead as long
     as possible.
     .
-Version:       0.10.1.4
+Version:       0.10.2
 License:       PublicDomain
 License-File:  COPYING
 Author:        Adam Langley, Mikhail Vorozhtsov, PHO, Taru Karttunen


### PR DESCRIPTION
Hello,

I work at Galois Inc., and we've been using your binding to the open-ssl library.  Thanks for your work!  We noticed that the bytestring API for the 'read' and 'write' operations is a bit slow as it puts a lot of pressure on the garbage collector: receiving data requires allocation of temporary byte-string buffers, which are then parsed into actual Haskell values for further use.

I added a couple of functions to allow sending and receiving data directly to a memory buffer.  This is useful because it makes it possible to reuse the same buffer for multiple operations, which leads to a significant gain in performance.   The functions are analogous to 'hPutVuf' and 'hGetBufSome' from the 'System.IO' module.

Could you please merge the change and upload a new version to Hackage?

Thanks for your work,
-Iavor
