### PR TITLE
Don't hardcode builddir path (it breaks with "cabal sandbox.").

### DIFF
--- a/HsOpenSSL.cabal
+++ b/HsOpenSSL.cabal
@@ -10,9 +10,9 @@ Description:
     This package is in production use by a number of Haskell based
     systems and stable. You may also be interested in the @tls@ package,
     <http://hackage.haskell.org/package/tls>, which is a pure Haskell
-    implementation of SSL. 
+    implementation of SSL.
     .
-Version:       0.10.3.3
+Version:       0.10.3.4
 License:       PublicDomain
 License-File:  COPYING
 Author:        Adam Langley, Mikhail Vorozhtsov, PHO, Taru Karttunen

--- a/cbits/HsOpenSSL.h
+++ b/cbits/HsOpenSSL.h
@@ -22,12 +22,9 @@
 
 /* A dirty hack to work around for broken versions of Cabal:
  * https://github.com/phonohawk/HsOpenSSL/issues/8
- *
- * The trick is to abuse the fact that -Icbits is always passed to
- * hsc2hs so we can reach the cabal_macros.h from cbits.
  */
 #if !defined(MIN_VERSION_base)
-#  include "../dist/build/autogen/cabal_macros.h"
+#  include "cabal_macros.h"
 #endif
 
 /* OpenSSL ********************************************************************/


### PR DESCRIPTION
Fixes #23, hopefully.
