### PR TITLE
Fix build of cbits/HsOpenSSL.c when using a different build dir

### DIFF
--- a/cbits/HsOpenSSL.h
+++ b/cbits/HsOpenSSL.h
@@ -27,7 +27,7 @@
  * hsc2hs so we can reach the cabal_macros.h from cbits.
  */
 #if !defined(MIN_VERSION_base)
-#  include "../dist/build/autogen/cabal_macros.h"
+#  include "autogen/cabal_macros.h"
 #endif
 
 /* OpenSSL ********************************************************************/


### PR DESCRIPTION
The build fails when using a different build directory than `dist`:

```
$ cabal configure --builddir=dist123
$ cabal build     --builddir=dist123

In file included from cbits/HsOpenSSL.c:1:0:

cbits/HsOpenSSL.h:30:50:
     fatal error: ../dist/build/autogen/cabal_macros.h: No such file or directory
compilation terminated.
```

This patch fixes it.

It would be great if this could be released soon because we have some production code relying on HsOpenSSL and our build system uses `hsenv` which uses another build directory than `dist`.
