### PR TITLE
add Server-example files to Extra-Source-Files

### DIFF
--- a/HsOpenSSL.cabal
+++ b/HsOpenSSL.cabal
@@ -34,6 +34,9 @@ Extra-Source-Files:
     examples/GenRSAKey.hs
     examples/HelloWorld.hs
     examples/PKCS7.hs
+    examples/Server.hs
+    examples/server.crt
+    examples/server.pem
     tests/Base64.hs
     tests/Cipher.hs
     tests/DSA.hs


### PR DESCRIPTION
the Server-example files aren't listed in Extra-Source-Files and so they aren't packaged
