### PR TITLE
Expose OpenSSL.EVP.Internal and cipherInit

### DIFF
--- a/HsOpenSSL.cabal
+++ b/HsOpenSSL.cabal
@@ -85,6 +85,7 @@ Library
           OpenSSL.EVP.Base64
           OpenSSL.EVP.Cipher
           OpenSSL.EVP.Digest
+          OpenSSL.EVP.Internal
           OpenSSL.EVP.Open
           OpenSSL.EVP.PKey
           OpenSSL.EVP.Seal
@@ -111,7 +112,6 @@ Library
           OpenSSL.Stack
           OpenSSL.Utils
           OpenSSL.X509.Name
-          OpenSSL.EVP.Internal
           OpenSSL.DH.Internal
   Extensions:
           ForeignFunctionInterface, EmptyDataDecls, MagicHash,

--- a/OpenSSL/EVP/Cipher.hsc
+++ b/OpenSSL/EVP/Cipher.hsc
@@ -11,6 +11,7 @@ module OpenSSL.EVP.Cipher
 
     , CryptoMode(..)
 
+    , cipherInit
     , cipher
     , cipherBS
     , cipherLBS


### PR DESCRIPTION
Current exposed cipher functions create new context each time, which is not helpful in some use cases.
Please consider expose OpenSSL.EVP.Internal (or at least cipherUpdateBS) and cipherInit.
