### PR TITLE
Add includes cabal declaration

### DIFF
--- a/HsOpenSSL.cabal
+++ b/HsOpenSSL.cabal
@@ -119,6 +119,8 @@ Library
         cbits/HsOpenSSL.c
     Include-Dirs:
         cbits
+    Includes:
+        openssl/asn1.h
 
 Test-Suite test-cipher
     Type:    exitcode-stdio-1.0


### PR DESCRIPTION
This will make already `cabal configure` (not `cabal build`) fail if headers cannot be found:

```
cabal: Missing dependency on a foreign library:
* Missing (or bad) header file: openssl/asn1.h
```
