### PR TITLE
Add DER encoding and decoding support for RSA public keys

### DIFF
--- a/HsOpenSSL.cabal
+++ b/HsOpenSSL.cabal
@@ -146,6 +146,19 @@ Test-Suite test-dsa
     GHC-Options:
         -Wall
 
+Test-Suite test-rsa
+    Type:    exitcode-stdio-1.0
+    Main-Is: Test/OpenSSL/RSA.hs
+    Build-Depends:
+        HsOpenSSL,
+        HUnit                >= 1.0 && < 1.3,
+        base                 == 4.*,
+        bytestring           >= 0.9 && < 0.11,
+        test-framework       >= 0.8 && < 0.9,
+        test-framework-hunit >= 0.3 && < 0.4
+    GHC-Options:
+        -Wall
+
 Test-Suite test-evp-base64
     Type:    exitcode-stdio-1.0
     Main-Is: Test/OpenSSL/EVP/Base64.hs

--- a/OpenSSL/RSA.hsc
+++ b/OpenSSL/RSA.hsc
@@ -24,19 +24,28 @@ module OpenSSL.RSA
     , rsaIQMP
     , rsaCopyPublic
     , rsaKeyPairFinalize -- private
+      -- * DER encoding
+    , fromDERPub
+    , toDERPub
     )
     where
 #include "HsOpenSSL.h"
 import Control.Monad
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as B (useAsCStringLen)
+import qualified Data.ByteString.Internal as BI (createAndTrim)
 import Data.Typeable
+import Foreign.C.String (CString)
 #if MIN_VERSION_base(4,5,0)
-import Foreign.C.Types (CInt(..))
+import Foreign.C.Types (CInt(..), CLong(..))
 #else
-import Foreign.C.Types (CInt)
+import Foreign.C.Types (CInt, CLong)
 #endif
 import Foreign.ForeignPtr (ForeignPtr, finalizeForeignPtr, newForeignPtr, withForeignPtr)
+import Foreign.Marshal.Alloc (alloca)
 import Foreign.Ptr (FunPtr, Ptr, freeHaskellFunPtr, nullFunPtr, nullPtr)
 import Foreign.Storable (Storable(..))
+import GHC.Word (Word8)
 import OpenSSL.BN
 import OpenSSL.Utils
 import System.IO.Unsafe (unsafePerformIO)
@@ -233,6 +242,31 @@ rsaDMQ1 = peekMI (#peek RSA, dmq1)
 rsaIQMP :: RSAKeyPair -> Maybe Integer
 rsaIQMP = peekMI (#peek RSA, iqmp)
 
+{- DER encoding ------------------------------------------------------------- -}
+
+foreign import ccall unsafe "d2i_RSAPublicKey"
+        _fromDERPub :: Ptr (Ptr RSA) -> Ptr CString -> CLong -> IO (Ptr RSA)
+
+foreign import ccall unsafe "i2d_RSAPublicKey"
+        _toDERPub :: Ptr RSA -> Ptr (Ptr Word8) -> IO CInt
+
+-- |Parse a public key from ASN.1 DER format
+fromDERPub :: ByteString -> Maybe RSAPubKey
+fromDERPub bs = unsafePerformIO . usingConvedBS $ \(csPtr, ci) -> do
+    rsaPtr <- _fromDERPub nullPtr csPtr ci
+    if rsaPtr == nullPtr then return Nothing else
+        Just . RSAPubKey <$> newForeignPtr _free rsaPtr
+    where usingConvedBS io = B.useAsCStringLen bs $ \(cs, len) ->
+              alloca $ \csPtr -> poke csPtr cs >> io (csPtr, fromIntegral len)
+
+-- |Dump a public key to ASN.1 DER format
+toDERPub :: RSAPubKey -> ByteString
+toDERPub (RSAPubKey k) = unsafePerformIO $ do
+    requiredSize <- withForeignPtr k $ flip _toDERPub nullPtr
+    BI.createAndTrim (fromIntegral requiredSize) $ \ptr ->
+        alloca $ \pptr ->
+            (fromIntegral <$>) $ withForeignPtr k $ \key ->
+                poke pptr ptr >> _toDERPub key pptr
 
 {- instances ---------------------------------------------------------------- -}
 

--- a/Test/OpenSSL/RSA.hs
+++ b/Test/OpenSSL/RSA.hs
@@ -1,0 +1,14 @@
+module Main (main) where
+import OpenSSL.RSA
+import qualified Test.Framework as TF
+import qualified Test.Framework.Providers.HUnit as TF
+import Test.HUnit
+
+test_encodeDecodeEqual :: Test
+test_encodeDecodeEqual = TestCase $ do
+  keyPair <- generateRSAKey 1024 3 Nothing
+  pubKey <- rsaCopyPublic keyPair
+  assertEqual "encodeDecode" (Just pubKey) (fromDERPub (toDERPub pubKey))
+
+main :: IO ()
+main = TF.defaultMain $ TF.hUnitTestToTests test_encodeDecodeEqual


### PR DESCRIPTION
This allows us to encode and decode RSA public keys in ASN.1 DER.